### PR TITLE
Validates search results from bugzilla

### DIFF
--- a/lib/shiftzilla/source.rb
+++ b/lib/shiftzilla/source.rb
@@ -30,7 +30,16 @@ module Shiftzilla
       retrieved     = []
       bz_csv.split("||EOR\n").each do |row|
         values = row.split("\x1F").map{ |v| v.strip }
+
+        # Validate input
         next unless values.length > 0
+        begin
+          next unless Integer(values[0]) > 0
+        rescue
+          puts "Error: `#{values[0]}` is not a valid Bug ID."
+          next
+        end
+
         if not @external_bugs_idx.nil?
           if not @external_sub.nil? and not values[@external_bugs_idx].nil? and values[@external_bugs_idx].include?(@external_sub)
             values[@external_bugs_idx] = 1


### PR DESCRIPTION
Adds a small bit of validation to the results coming from bugzilla.  This
should prevent any status messages being added to the database as bugs.

This change should check to make sure that the bugzilla ID can be converted to an integer, and if it fails, will catch the exception and skip that row.  In the case of a status message being the only thing returned, it will skip the only row and 0 rows will be added.

Tested locally without setting a bugzilla login token to trigger a status message.  Shiftzilla load will now gracefully get 0 retrieved rows as well as displaying an error message.  Shiftzilla load works as expected after adding the bugzilla token back in.

