### PR TITLE
Adds else to fix crashing on bad commands

### DIFF
--- a/bin/shiftzilla
+++ b/bin/shiftzilla
@@ -101,6 +101,8 @@ when 'help'
 when 'version'
   puts Shiftzilla::VERSION
   exit 0
+else
+  Optimist::educate
 end
 
 if cmd_opts.has_key?(:cfgpath)


### PR DESCRIPTION
Doing `shiftzilla summary` like the readme says actually results in a traceback because summary is not a valid command and there was no handling of invalid commands.

Adds a very basic check for non-valid commands and spits back the `--help` text.