### PR TITLE
Adds ruby 2.4 requirement to gemspec

### DIFF
--- a/shiftzilla.gemspec
+++ b/shiftzilla.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.4'
+
   spec.add_development_dependency 'bundler', '~> 1.16', '>= 1.16.1'
 
   spec.add_dependency 'fileutils',      '~> 1.0', '>= 1.0.2'


### PR DESCRIPTION
The `sum` method on an array requires ruby 2.4.  Adds ruby 2.4 as the minimum required ruby for the shiftzilla gem.