### PR TITLE
Removes release_clause and version bump

### DIFF
--- a/lib/shiftzilla/engine.rb
+++ b/lib/shiftzilla/engine.rb
@@ -34,8 +34,6 @@ module Shiftzilla
           menu.choice(:yes) {
             say("Okay. Creating #{Shiftzilla::DB_FPATH}")
             sql_tmpl       = File.read(SQL_TMPL)
-            tgt_rel_clause = release_clause(releases)
-            sql_tmpl.gsub! '$RELEASE_CLAUSE', tgt_rel_clause
             dbh.execute_batch(sql_tmpl)
             dbh.close
             exit

--- a/lib/shiftzilla/version.rb
+++ b/lib/shiftzilla/version.rb
@@ -1,3 +1,3 @@
 module Shiftzilla
-  VERSION = "0.2.22"
+  VERSION = "0.2.23"
 end


### PR DESCRIPTION
The feature that replaces a variable from the sqlite template file was removed
some time ago. Removes this code.

Version bump to 0.2.23