### PR TITLE
Change beta symbol to html entity

### DIFF
--- a/template.haml
+++ b/template.haml
@@ -146,7 +146,7 @@
                 - all_bugs.each do |b|
                   %tr
                     %td
-                      = b.beta_blocker ? "<span class='badge badge-info'>ßeta</span>" : ''
+                      = b.beta_blocker ? "<span class='badge badge-info'>&#946;eta</span>" : ''
                       = b.test_blocker ? "<span class='badge badge-danger'>Test</span>" : ''
                       = b.ops_blocker ? "<span class='badge badge-dark'>Ops</span>" : ''
                       = b.online_blocker ? "<span class='badge badge-warning'>Online</span>" : ''


### PR DESCRIPTION
Ruby inherits locale from the environment, which is US-ASCII for some reason in
docker containers. Change to the html entity so the locale doesn't matter.