### PR TITLE
Adds group aggregation

### DIFF
--- a/bin/shiftzilla
+++ b/bin/shiftzilla
@@ -66,6 +66,7 @@ EOF
     opt :quiet, "For cron use; don't print anything to STDOUT.", :default => false
     opt :cfgpath, "Specify a config file for shiftzilla to use.", :default => "#{DEFAULT_DIR}/shiftzilla_cfg.yaml"
     opt :dbpath, "Specify a database file location for shiftzilla to use.", :default => "#{DEFAULT_DIR}/shiftzilla.sqlite"
+    opt :groups, "Enable group aggregation table on main page", :default => false
   end
 when 'purge'
   Optimist::options do

--- a/lib/shiftzilla/config.rb
+++ b/lib/shiftzilla/config.rb
@@ -22,6 +22,7 @@ module Shiftzilla
       cfg_file['Teams'].each do |team|
         @teams << Shiftzilla::Team.new(team,group_map)
       end
+      update_group_components
       cfg_file['Sources'].each do |sid,sinfo|
         @sources << Shiftzilla::Source.new(sid,sinfo)
       end
@@ -48,6 +49,10 @@ module Shiftzilla
 
     def team(tname)
       @teams.select{ |t| t.name == tname }[0]
+    end
+
+    def group(gname)
+      @groups.select{ |g| g.id == gname[0] }[0]
     end
 
     def add_ad_hoc_team(tinfo)
@@ -95,5 +100,18 @@ module Shiftzilla
         boundaries
       end
     end
+
+    def update_group_components
+      @groups.each do |g|
+        components = []
+        @teams.each do |t|
+          if t.group and (t.group.id == g.id)
+            components += t.components
+          end
+        end
+        g.set_components(components)
+      end
+    end
+
   end
 end

--- a/lib/shiftzilla/config.rb
+++ b/lib/shiftzilla/config.rb
@@ -22,7 +22,7 @@ module Shiftzilla
       cfg_file['Teams'].each do |team|
         @teams << Shiftzilla::Team.new(team,group_map)
       end
-      update_group_components
+      set_group_components
       cfg_file['Sources'].each do |sid,sinfo|
         @sources << Shiftzilla::Source.new(sid,sinfo)
       end
@@ -101,7 +101,7 @@ module Shiftzilla
       end
     end
 
-    def update_group_components
+    def set_group_components
       @groups.each do |g|
         components = []
         @teams.each do |t|

--- a/lib/shiftzilla/engine.rb
+++ b/lib/shiftzilla/engine.rb
@@ -113,7 +113,7 @@ module Shiftzilla
       org_data = Shiftzilla::OrgData.new(shiftzilla_config)
       org_data.populate_releases
       org_data.build_series
-      org_data.generate_reports
+      org_data.generate_reports(options[:groups])
       if options[:local_preview]
         org_data.show_local_reports
       else

--- a/lib/shiftzilla/group.rb
+++ b/lib/shiftzilla/group.rb
@@ -6,11 +6,10 @@ module Shiftzilla
       @name        = "Group " + ginfo['id']
       @id          = ginfo['id']
       @lead        = ginfo['lead']
-      @components  = []
     end
 
     def set_components(component_list)
-      @components += component_list
+      @components ||= component_list
     end
 
   end

--- a/lib/shiftzilla/group.rb
+++ b/lib/shiftzilla/group.rb
@@ -1,10 +1,17 @@
 module Shiftzilla
   class Group
-    attr_reader :id, :lead
+    attr_reader :name, :id, :lead, :components
 
     def initialize(ginfo)
-      @id    = ginfo['id']
-      @lead  = ginfo['lead']
+      @name        = "Group " + ginfo['id']
+      @id          = ginfo['id']
+      @lead        = ginfo['lead']
+      @components  = []
     end
+
+    def set_components(component_list)
+      @components += component_list
+    end
+
   end
 end

--- a/lib/shiftzilla/helpers.rb
+++ b/lib/shiftzilla/helpers.rb
@@ -249,6 +249,8 @@ module Shiftzilla
           errors << "Team at index #{list_idx} is missing the 'name' key."
         elsif not valid_config_string?(team['name'])
           errors << "Team at index #{list_idx} has a nil or zero-length 'name'."
+        elsif team['name'].start_with?("Group")
+          errors << "Team at index #{list_idx} begins with the string 'Group'."
         else
           tnm = team['name']
           if seen_tnms.has_key?(tnm)

--- a/lib/shiftzilla/org_data.rb
+++ b/lib/shiftzilla/org_data.rb
@@ -186,6 +186,7 @@ module Shiftzilla
           :tname          => tdata.title,
           :file           => tdata.file,
           :releases       => {},
+          :is_group       => (not @group_teams.detect{|g| g.name == tdata.title}.nil?),
         }
 
         @releases.each do |release|
@@ -229,11 +230,14 @@ module Shiftzilla
           :latest_snapshot => latest_snapshot,
           :all_bugs        => [],
           :include_groups  => include_groups,
+          :is_group        => false,
         }
 
         # Check if this is actually a group "team"
-        if tname.start_with?("Group")
-          team_pinfo[:tinfo] = @group_teams.select{|g| g.name == tname}[0]
+        group_match = @group_teams.detect{|g| g.name == tname}
+        unless group_match.nil?
+          team_pinfo[:tinfo] = group_match
+          team_pinfo[:is_group] = true
         end
 
         @releases.each do |release|

--- a/lib/shiftzilla/version.rb
+++ b/lib/shiftzilla/version.rb
@@ -1,3 +1,3 @@
 module Shiftzilla
-  VERSION = "0.2.26"
+  VERSION = "0.2.27"
 end

--- a/template.haml
+++ b/template.haml
@@ -45,7 +45,8 @@
           - if tname != '_overall' and not tinfo.nil? and not tinfo.ad_hoc?
             %h5 Team Info
             %ul
-              %li= "Team Lead: #{tinfo.lead}"
+              - unless tname.start_with?("Group")
+                %li= "Team Lead: #{tinfo.lead}"
               - if not tinfo.group.nil? and not tinfo.group.lead.nil?
                 %li= "Group Lead: #{tinfo.group.lead}"
               - if tinfo.components.length > 0
@@ -69,7 +70,7 @@
               - releases.each do |r|
                 %td.text-right= r[:bug_avg_age]
             %tr
-              %td Avg. Test Blocker Age
+              %td Avg. Blocker Age
               - releases.each do |r|
                 %td.text-right= r[:tb_avg_age]
             %tr
@@ -81,7 +82,7 @@
               - releases.each do |r|
                 %td.text-right= r[:snapdata].closed_bugs
             %tr
-              %td Test / Ops Blockers
+              %td Blockers
               - releases.each do |r|
                 %td.text-right= r[:snapdata].total_tb
             %tr
@@ -92,6 +93,26 @@
               %td Closed Blockers Yesterday
               - releases.each do |r|
                 %td.text-right= r[:snapdata].closed_tb
+
+          - if tname == '_overall' and include_groups
+            %h5 Totals By Group
+            %table.table.table-hover.table-sm
+              %tr
+                %td Group
+                - releases.each do |r|
+                  %td.text-right= r[:release].name
+              - team_files.each do |tm|
+                - if not tm[:tname].start_with?("Group")
+                  - next
+                %tr
+                  %td
+                    - if tm[:tname] == tdisp
+                      = tdisp
+                    - else
+                      %a{ :href => tm[:file] }= tm[:tname]
+                  - releases.each do |r|
+                    %td.text-right= tm[:releases][r[:release].name]
+
           - if tname == '_overall'
             %h5 Totals By Team
             %table.table.table-hover.table-sm
@@ -100,6 +121,8 @@
                 - releases.each do |r|
                   %td.text-right= r[:release].name
               - team_files.each do |tm|
+                - if tm[:tname].start_with?("Group")
+                  - next
                 %tr
                   %td
                     - if tm[:tname] == tdisp

--- a/template.haml
+++ b/template.haml
@@ -45,7 +45,7 @@
           - if tname != '_overall' and not tinfo.nil? and not tinfo.ad_hoc?
             %h5 Team Info
             %ul
-              - unless tname.start_with?("Group")
+              - unless is_group
                 %li= "Team Lead: #{tinfo.lead}"
               - if not tinfo.group.nil? and not tinfo.group.lead.nil?
                 %li= "Group Lead: #{tinfo.group.lead}"
@@ -102,7 +102,7 @@
                 - releases.each do |r|
                   %td.text-right= r[:release].name
               - team_files.each do |tm|
-                - if not tm[:tname].start_with?("Group")
+                - unless tm[:is_group]
                   - next
                 %tr
                   %td
@@ -121,7 +121,7 @@
                 - releases.each do |r|
                   %td.text-right= r[:release].name
               - team_files.each do |tm|
-                - if tm[:tname].start_with?("Group")
+                - if tm[:is_group]
                   - next
                 %tr
                   %td


### PR DESCRIPTION
Shiftzilla will now track data at the group level.

* Data is aggregated at a group level
* Each Group will now how its own breakdown page, similar to teams.
* The "Totals By Group" table will appear on the _overall page if Shiftzilla is built with the `--groups` flag
* Renames Test/Ops Blockers to the more general Blockers in several places
* Adds error to config check if a team name starts with "Group"
* Version bump to 0.2.27