### PR TITLE
Add component->team links on Group pages

### DIFF
--- a/template.haml
+++ b/template.haml
@@ -50,7 +50,7 @@
               - if not tinfo.group.nil? and not tinfo.group.lead.nil?
                 %li= "Group Lead: #{tinfo.group.lead}"
               - if tinfo.components.length > 0
-                %li= "BZ Component(s): #{tinfo.components.join(', ')}"
+                %li= "BZ Component(s): " + tinfo.components.map{ |c| "<a href='component_#{c}.html'>#{c}</a>"}.join(', ')
           %h5= "#{tdisp} Summary"
           %table.table.table-hover.table-sm
             %tr


### PR DESCRIPTION
Turns each component listed on the Group pages into a link to a simple .html
file that will redirect to the appropriate team page.

This is one of the several changes planned for Shiftzilla 0.2.28 and will eventually be bundled with a version bump.