### PR TITLE
Add option for variable milestone dates

### DIFF
--- a/lib/shiftzilla/helpers.rb
+++ b/lib/shiftzilla/helpers.rb
@@ -331,10 +331,14 @@ module Shiftzilla
               if not milestones.has_key?(ms)
                 errors << "Release at index #{list_idx} is missing the '#{ms}' milestone."
               else
+                if milestones[ms] == 'today' or !!(milestones[ms] =~ /today[+-]\d+[dwms]/)
+                  # Matches the variable date format
+                  next
+                end
                 ms_date = milestones[ms].split('-')
                 if ms_date.length == 3 and ms_date[0].length == 4 and ms_date[1].length == 2 and ms_date[2].length == 2
                 else
-                  errors << "Release at index #{list_idx}: milestone '#{ms}' is not formatted correctly (YYYY-MM-DD)."
+                  errors << "Release at index #{list_idx}: milestone '#{ms}' is not formatted correctly - (YYYY-MM-DD) or (today[+-]X[dwms])."
                 end
               end
             end

--- a/lib/shiftzilla/milestone.rb
+++ b/lib/shiftzilla/milestone.rb
@@ -1,9 +1,14 @@
+require 'date'
+
 module Shiftzilla
   class Milestone
     def initialize(mtxt)
       @date  = nil
       @stamp = ''
-      unless (mtxt.nil? or mtxt == '')
+      if mtxt.start_with?('today')
+        @date = variable_date(mtxt)
+        @stamp = @date.strftime('%Y-%m-%d')
+      elsif not (mtxt.nil? or mtxt == '')
         @date  = Date.parse(mtxt)
         @stamp = mtxt
       end
@@ -15,6 +20,43 @@ module Shiftzilla
 
     def stamp
       @stamp
+    end
+
+    private
+
+    def variable_date(d)
+      # Takes a variable date string and returns the appropriate date object
+      # Variable dates of the form today[+,-]#[d,w,m,s]
+      today = Date.today
+
+      if d.length < 8
+        return today
+      end
+
+      operation = d[5]
+      val = d[6..-2].to_i
+      unit = d[-1]
+      days = 0
+
+      # Convert to days for simple addition
+      case unit
+      when 'd'
+        days = val
+      when 'w'
+        days = 7*val
+      when 'm'
+        days = 30*val
+      when 's'      # Sprints
+        days = 21*val
+      else
+        days = val
+      end
+
+      if operation == '-'
+        days = days * -1
+      end
+
+      return today+days
     end
   end
 end


### PR DESCRIPTION
Adds the ability to use shifting milestone dates that will change each time
shiftzilla is built.  This enables better graphing of rolling releases.

The dates must be of the format "today[+-][0-9]+[dwms]".

For example:
* today+5d will return the date 5 days from now
* today+1w will return the date 7 days from now
* today-1m will return the date 30 days ago
* today+2s will return the date 42 days from now (2 sprints)