### PR TITLE
Bump version to 0.2.28

### DIFF
--- a/lib/shiftzilla/org_data.rb
+++ b/lib/shiftzilla/org_data.rb
@@ -40,7 +40,7 @@ module Shiftzilla
 
           # TODO: REMOVE BUSINESS LOGIC EMBEDDED IN CODE
           if comp == 'Security' and keyw.include?('Unconfirmed')
-            puts "NB: This report has a hardcoded exclusion of 'Security' component bugs with the 'Unconfirmed' keyword."
+            # This report has a hardcoded exclusion of 'Security' component bugs with the 'Unconfirmed' keyword."
             next
           end
 

--- a/lib/shiftzilla/version.rb
+++ b/lib/shiftzilla/version.rb
@@ -1,3 +1,3 @@
 module Shiftzilla
-  VERSION = "0.2.27"
+  VERSION = "0.2.28"
 end


### PR DESCRIPTION
Version bump.  Also comments out the warning about hard-coded security issues,
which spams the logs.


For merge after #17 and #18.